### PR TITLE
Closes #18 Clarify configuration precedence and override rules in docs

### DIFF
--- a/__sandbox7/BellmanFord.test.js
+++ b/__sandbox7/BellmanFord.test.js
@@ -1,0 +1,51 @@
+import { BellmanFord } from '../BellmanFord.js'
+
+test('Test Case 1', () => {
+  const V = 5
+  const E = 8
+  const destination = 3
+  const graph = [
+    [0, 1, -1],
+    [0, 2, 4],
+    [1, 2, 3],
+    [1, 3, 2],
+    [1, 4, 2],
+    [3, 2, 5],
+    [3, 1, 1],
+    [4, 3, -3]
+  ]
+  const dist = BellmanFord(graph, V, E, 0, destination)
+  expect(dist).toBe(-2)
+})
+test('Test Case 2', () => {
+  const V = 6
+  const E = 9
+  const destination = 4
+  const graph = [
+    [0, 1, 3],
+    [0, 3, 6],
+    [0, 5, -1],
+    [1, 2, -3],
+    [1, 4, -2],
+    [5, 2, 5],
+    [2, 3, 1],
+    [4, 3, 5],
+    [5, 4, 2]
+  ]
+  const dist = BellmanFord(graph, V, E, 0, destination)
+  expect(dist).toBe(1)
+})
+test('Test Case 3', () => {
+  const V = 4
+  const E = 5
+  const destination = 1
+  const graph = [
+    [0, 3, -1],
+    [0, 2, 4],
+    [3, 2, 2],
+    [3, 1, 5],
+    [2, 1, -1]
+  ]
+  const dist = BellmanFord(graph, V, E, 0, destination)
+  expect(dist).toBe(0)
+})

--- a/__sandbox7/DamerauLevenshteinDistanceTest.java
+++ b/__sandbox7/DamerauLevenshteinDistanceTest.java
@@ -1,0 +1,194 @@
+package com.thealgorithms.dynamicprogramming;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Unit tests for the {@code DamerauLevenshteinDistance} class.
+ * Tests cover edge cases, basic operations, and complex transposition scenarios.
+ */
+class DamerauLevenshteinDistanceTest {
+
+    @Test
+    @DisplayName("Should throw exception for null first string")
+    void testNullFirstString() {
+        assertThrows(IllegalArgumentException.class, () -> { DamerauLevenshteinDistance.distance(null, "test"); });
+    }
+
+    @Test
+    @DisplayName("Should throw exception for null second string")
+    void testNullSecondString() {
+        assertThrows(IllegalArgumentException.class, () -> { DamerauLevenshteinDistance.distance("test", null); });
+    }
+
+    @Test
+    @DisplayName("Should throw exception for both null strings")
+    void testBothNullStrings() {
+        assertThrows(IllegalArgumentException.class, () -> { DamerauLevenshteinDistance.distance(null, null); });
+    }
+
+    @Test
+    @DisplayName("Should return 0 for identical strings")
+    void testIdenticalStrings() {
+        assertEquals(0, DamerauLevenshteinDistance.distance("", ""));
+        assertEquals(0, DamerauLevenshteinDistance.distance("a", "a"));
+        assertEquals(0, DamerauLevenshteinDistance.distance("abc", "abc"));
+        assertEquals(0, DamerauLevenshteinDistance.distance("hello", "hello"));
+    }
+
+    @Test
+    @DisplayName("Should return length when one string is empty")
+    void testEmptyStrings() {
+        assertEquals(3, DamerauLevenshteinDistance.distance("", "abc"));
+        assertEquals(5, DamerauLevenshteinDistance.distance("hello", ""));
+        assertEquals(0, DamerauLevenshteinDistance.distance("", ""));
+    }
+
+    @Test
+    @DisplayName("Should handle single character insertions")
+    void testSingleInsertion() {
+        assertEquals(1, DamerauLevenshteinDistance.distance("cat", "cats"));
+        assertEquals(1, DamerauLevenshteinDistance.distance("ab", "abc"));
+        assertEquals(1, DamerauLevenshteinDistance.distance("", "a"));
+    }
+
+    @Test
+    @DisplayName("Should handle single character deletions")
+    void testSingleDeletion() {
+        assertEquals(1, DamerauLevenshteinDistance.distance("cats", "cat"));
+        assertEquals(1, DamerauLevenshteinDistance.distance("abc", "ab"));
+        assertEquals(1, DamerauLevenshteinDistance.distance("a", ""));
+    }
+
+    @Test
+    @DisplayName("Should handle single character substitutions")
+    void testSingleSubstitution() {
+        assertEquals(1, DamerauLevenshteinDistance.distance("cat", "bat"));
+        assertEquals(1, DamerauLevenshteinDistance.distance("abc", "adc"));
+        assertEquals(1, DamerauLevenshteinDistance.distance("x", "y"));
+    }
+
+    @Test
+    @DisplayName("Should handle adjacent character transpositions")
+    void testAdjacentTransposition() {
+        assertEquals(1, DamerauLevenshteinDistance.distance("ab", "ba"));
+        assertEquals(1, DamerauLevenshteinDistance.distance("abc", "bac"));
+        assertEquals(1, DamerauLevenshteinDistance.distance("hello", "ehllo"));
+    }
+
+    @Test
+    @DisplayName("Should correctly compute distance for CA to ABC")
+    void testCAtoABC() {
+        // This is the critical test case that differentiates full DL from OSA
+        // Full DL: 2 (insert A at start, insert B in middle)
+        // OSA would give: 3
+        assertEquals(2, DamerauLevenshteinDistance.distance("CA", "ABC"));
+    }
+
+    @Test
+    @DisplayName("Should handle non-adjacent transpositions")
+    void testNonAdjacentTransposition() {
+        assertEquals(2, DamerauLevenshteinDistance.distance("abc", "cba"));
+        assertEquals(3, DamerauLevenshteinDistance.distance("abcd", "dcba"));
+    }
+
+    @Test
+    @DisplayName("Should handle multiple operations")
+    void testMultipleOperations() {
+        assertEquals(3, DamerauLevenshteinDistance.distance("kitten", "sitting"));
+        assertEquals(3, DamerauLevenshteinDistance.distance("saturday", "sunday"));
+        assertEquals(5, DamerauLevenshteinDistance.distance("intention", "execution"));
+    }
+
+    @Test
+    @DisplayName("Should handle completely different strings")
+    void testCompletelyDifferentStrings() {
+        assertEquals(3, DamerauLevenshteinDistance.distance("abc", "xyz"));
+        assertEquals(4, DamerauLevenshteinDistance.distance("hello", "world"));
+    }
+
+    @Test
+    @DisplayName("Should handle strings with repeated characters")
+    void testRepeatedCharacters() {
+        assertEquals(0, DamerauLevenshteinDistance.distance("aaa", "aaa"));
+        assertEquals(1, DamerauLevenshteinDistance.distance("aaa", "aab"));
+        assertEquals(1, DamerauLevenshteinDistance.distance("aaa", "aba"));
+    }
+
+    @Test
+    @DisplayName("Should be symmetric")
+    void testSymmetry() {
+        assertEquals(DamerauLevenshteinDistance.distance("abc", "def"), DamerauLevenshteinDistance.distance("def", "abc"));
+        assertEquals(DamerauLevenshteinDistance.distance("hello", "world"), DamerauLevenshteinDistance.distance("world", "hello"));
+    }
+
+    @Test
+    @DisplayName("Should handle case sensitivity")
+    void testCaseSensitivity() {
+        assertEquals(1, DamerauLevenshteinDistance.distance("Hello", "hello"));
+        assertEquals(5, DamerauLevenshteinDistance.distance("HELLO", "hello"));
+    }
+
+    @Test
+    @DisplayName("Should handle single character strings")
+    void testSingleCharacterStrings() {
+        assertEquals(1, DamerauLevenshteinDistance.distance("a", "b"));
+        assertEquals(0, DamerauLevenshteinDistance.distance("a", "a"));
+        assertEquals(2, DamerauLevenshteinDistance.distance("a", "abc"));
+    }
+
+    @Test
+    @DisplayName("Should handle long strings efficiently")
+    void testLongStrings() {
+        String s1 = "abcdefghijklmnopqrstuvwxyz";
+        String s2 = "abcdefghijklmnopqrstuvwxyz";
+        assertEquals(0, DamerauLevenshteinDistance.distance(s1, s2));
+
+        String s3 = "abcdefghijklmnopqrstuvwxyz";
+        String s4 = "zyxwvutsrqponmlkjihgfedcba";
+        assertEquals(25, DamerauLevenshteinDistance.distance(s3, s4));
+    }
+
+    @Test
+    @DisplayName("Should satisfy triangle inequality")
+    void testTriangleInequality() {
+        // d(a,c) <= d(a,b) + d(b,c)
+        String a = "cat";
+        String b = "hat";
+        String c = "rat";
+
+        int ab = DamerauLevenshteinDistance.distance(a, b);
+        int bc = DamerauLevenshteinDistance.distance(b, c);
+        int ac = DamerauLevenshteinDistance.distance(a, c);
+
+        assertTrue(ac <= ab + bc);
+    }
+
+    @Test
+    @DisplayName("Should handle special characters")
+    void testSpecialCharacters() {
+        assertEquals(0, DamerauLevenshteinDistance.distance("hello!", "hello!"));
+        assertEquals(1, DamerauLevenshteinDistance.distance("hello!", "hello?"));
+        assertEquals(1, DamerauLevenshteinDistance.distance("a@b", "a#b"));
+    }
+
+    @Test
+    @DisplayName("Should handle numeric strings")
+    void testNumericStrings() {
+        assertEquals(1, DamerauLevenshteinDistance.distance("123", "124"));
+        assertEquals(1, DamerauLevenshteinDistance.distance("123", "213"));
+        assertEquals(0, DamerauLevenshteinDistance.distance("999", "999"));
+    }
+
+    @Test
+    @DisplayName("Should handle unicode characters")
+    void testUnicodeCharacters() {
+        assertEquals(0, DamerauLevenshteinDistance.distance("café", "café"));
+        assertEquals(1, DamerauLevenshteinDistance.distance("café", "cafe"));
+        assertEquals(0, DamerauLevenshteinDistance.distance("你好", "你好"));
+    }
+}

--- a/__sandbox7/DecimalToRoman.js
+++ b/__sandbox7/DecimalToRoman.js
@@ -1,0 +1,52 @@
+/*
+    Decimal To Roman
+
+    This algorithm take decimal number and convert to roman numeral according to standard form (https://en.wikipedia.org/wiki/Roman_numerals#Description)
+
+    Algorithm & Explanation : https://www.rapidtables.com/convert/number/how-number-to-roman-numerals.html
+*/
+
+const values = {
+  M: 1000,
+  CM: 900,
+  D: 500,
+  CD: 400,
+  C: 100,
+  XC: 90,
+  L: 50,
+  XL: 40,
+  X: 10,
+  IX: 9,
+  V: 5,
+  IV: 4,
+  I: 1
+}
+
+const orders = [
+  'M',
+  'CM',
+  'D',
+  'CD',
+  'C',
+  'XC',
+  'L',
+  'XL',
+  'X',
+  'IX',
+  'V',
+  'IV',
+  'I'
+]
+
+function decimalToRoman(num) {
+  let roman = ''
+  for (const symbol of orders) {
+    while (num >= values[symbol]) {
+      roman += symbol
+      num -= values[symbol]
+    }
+  }
+  return roman
+}
+
+export { decimalToRoman }

--- a/__sandbox7/IDirectedWeightedGraph.cs
+++ b/__sandbox7/IDirectedWeightedGraph.cs
@@ -1,0 +1,22 @@
+namespace DataStructures.Graph;
+
+public interface IDirectedWeightedGraph<T>
+{
+    int Count { get; }
+
+    Vertex<T>?[] Vertices { get; }
+
+    void AddEdge(Vertex<T> startVertex, Vertex<T> endVertex, double weight);
+
+    Vertex<T> AddVertex(T data);
+
+    bool AreAdjacent(Vertex<T> startVertex, Vertex<T> endVertex);
+
+    double AdjacentDistance(Vertex<T> startVertex, Vertex<T> endVertex);
+
+    IEnumerable<Vertex<T>?> GetNeighbors(Vertex<T> vertex);
+
+    void RemoveEdge(Vertex<T> startVertex, Vertex<T> endVertex);
+
+    void RemoveVertex(Vertex<T> vertex);
+}

--- a/__sandbox7/decimal_to_octal.rs
+++ b/__sandbox7/decimal_to_octal.rs
@@ -1,0 +1,37 @@
+// Author: NithinU2802
+// Decimal to Octal Converter: Converts Decimal to Octal
+// Wikipedia References:
+// 1. https://en.wikipedia.org/wiki/Decimal
+// 2. https://en.wikipedia.org/wiki/Octal
+
+pub fn decimal_to_octal(decimal_num: u64) -> String {
+    if decimal_num == 0 {
+        return "0".to_string();
+    }
+
+    let mut num = decimal_num;
+    let mut octal = String::new();
+
+    while num > 0 {
+        let remainder = num % 8;
+        octal.push_str(&remainder.to_string());
+        num /= 8;
+    }
+
+    // Reverse the string to get the correct octal representation
+    octal.chars().rev().collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_decimal_to_octal() {
+        assert_eq!(decimal_to_octal(8), "10");
+        assert_eq!(decimal_to_octal(15), "17");
+        assert_eq!(decimal_to_octal(255), "377");
+        assert_eq!(decimal_to_octal(100), "144");
+        assert_eq!(decimal_to_octal(0), "0");
+    }
+}


### PR DESCRIPTION
18 Decided to archive the experimental bias-correction module as 'won't fix' due to a 400% increase in inference time during benchmarking. The accuracy gains were negligible compared to the massive performance hit on standard laboratory hardware. We will focus on more efficient normalization strategies instead.