### PR TITLE
Closes #61 Mark identical to #789: Conda environment resolution timeout

### DIFF
--- a/__play4/Xs3ConversionTest.java
+++ b/__play4/Xs3ConversionTest.java
@@ -1,0 +1,65 @@
+package com.thealgorithms.bitmanipulation;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * Unit tests for the Xs3Conversion class.
+ */
+public class Xs3ConversionTest {
+
+    /**
+     * Test the xs3ToBinary method with an XS-3 number.
+     */
+    @Test
+    public void testXs3ToBinary() {
+        int binary = Xs3Conversion.xs3ToBinary(0x4567);
+        assertEquals(1234, binary); // XS-3 0x4567 should convert to binary 1234
+    }
+
+    /**
+     * Test the binaryToXs3 method with a binary number.
+     */
+    @Test
+    public void testBinaryToXs3() {
+        int xs3 = Xs3Conversion.binaryToXs3(1234);
+        assertEquals(0x4567, xs3); // Binary 1234 should convert to XS-3 0x4567
+    }
+
+    /**
+     * Test the xs3ToBinary method with zero.
+     */
+    @Test
+    public void testXs3ToBinaryZero() {
+        int binary = Xs3Conversion.xs3ToBinary(0x0);
+        assertEquals(0, binary); // XS-3 0x0 should convert to binary 0
+    }
+
+    /**
+     * Test the binaryToXs3 method with zero.
+     */
+    @Test
+    public void testBinaryToXs3Zero() {
+        int xs3 = Xs3Conversion.binaryToXs3(0);
+        assertEquals(0x0, xs3); // Binary 0 should convert to XS-3 0x0
+    }
+
+    /**
+     * Test the xs3ToBinary method with a single digit XS-3 number.
+     */
+    @Test
+    public void testXs3ToBinarySingleDigit() {
+        int binary = Xs3Conversion.xs3ToBinary(0x5);
+        assertEquals(2, binary); // XS-3 0x5 should convert to binary 2
+    }
+
+    /**
+     * Test the binaryToXs3 method with a single digit binary number.
+     */
+    @Test
+    public void testBinaryToXs3SingleDigit() {
+        int xs3 = Xs3Conversion.binaryToXs3(2);
+        assertEquals(0x5, xs3); // Binary 2 should convert to XS-3 0x5
+    }
+}

--- a/__play4/mirror_binary_tree.py
+++ b/__play4/mirror_binary_tree.py
@@ -1,0 +1,160 @@
+"""
+Given the root of a binary tree, mirror the tree, and return its root.
+
+Leetcode problem reference: https://leetcode.com/problems/mirror-binary-tree/
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from dataclasses import dataclass
+
+
+@dataclass
+class Node:
+    """
+    A Node has value variable and pointers to Nodes to its left and right.
+    """
+
+    value: int
+    left: Node | None = None
+    right: Node | None = None
+
+    def __iter__(self) -> Iterator[int]:
+        if self.left:
+            yield from self.left
+        yield self.value
+        if self.right:
+            yield from self.right
+
+    def __len__(self) -> int:
+        return sum(1 for _ in self)
+
+    def mirror(self) -> Node:
+        """
+        Mirror the binary tree rooted at this node by swapping left and right children.
+
+        >>> tree = Node(0)
+        >>> list(tree)
+        [0]
+        >>> list(tree.mirror())
+        [0]
+        >>> tree = Node(1, Node(0), Node(3, Node(2), Node(4, None, Node(5))))
+        >>> tuple(tree)
+        (0, 1, 2, 3, 4, 5)
+        >>> tuple(tree.mirror())
+        (5, 4, 3, 2, 1, 0)
+        """
+        self.left, self.right = self.right, self.left
+        if self.left:
+            self.left.mirror()
+        if self.right:
+            self.right.mirror()
+        return self
+
+
+def make_tree_seven() -> Node:
+    r"""
+    Return a binary tree with 7 nodes that looks like this:
+    ::
+
+           1
+         /   \
+        2     3
+       / \   / \
+      4   5 6   7
+
+    >>> tree_seven = make_tree_seven()
+    >>> len(tree_seven)
+    7
+    >>> list(tree_seven)
+    [4, 2, 5, 1, 6, 3, 7]
+    """
+    tree = Node(1)
+    tree.left = Node(2)
+    tree.right = Node(3)
+    tree.left.left = Node(4)
+    tree.left.right = Node(5)
+    tree.right.left = Node(6)
+    tree.right.right = Node(7)
+    return tree
+
+
+def make_tree_nine() -> Node:
+    r"""
+    Return a binary tree with 9 nodes that looks like this:
+    ::
+
+            1
+           / \
+          2   3
+         / \   \
+        4   5   6
+       / \   \
+      7   8   9
+
+    >>> tree_nine = make_tree_nine()
+    >>> len(tree_nine)
+    9
+    >>> list(tree_nine)
+    [7, 4, 8, 2, 5, 9, 1, 3, 6]
+    """
+    tree = Node(1)
+    tree.left = Node(2)
+    tree.right = Node(3)
+    tree.left.left = Node(4)
+    tree.left.right = Node(5)
+    tree.right.right = Node(6)
+    tree.left.left.left = Node(7)
+    tree.left.left.right = Node(8)
+    tree.left.right.right = Node(9)
+    return tree
+
+
+def main() -> None:
+    r"""
+    Mirror binary trees with the given root and returns the root
+
+    >>> tree = make_tree_nine()
+    >>> tuple(tree)
+    (7, 4, 8, 2, 5, 9, 1, 3, 6)
+    >>> tuple(tree.mirror())
+    (6, 3, 1, 9, 5, 2, 8, 4, 7)
+
+    nine_tree::
+
+            1
+           / \
+          2   3
+         / \   \
+        4   5   6
+       / \   \
+      7   8   9
+
+    The mirrored tree looks like this::
+
+          1
+         / \
+        3   2
+       /   / \
+      6   5   4
+         /   / \
+        9   8   7
+    """
+    trees = {"zero": Node(0), "seven": make_tree_seven(), "nine": make_tree_nine()}
+    for name, tree in trees.items():
+        print(f"      The {name} tree: {tuple(tree)}")
+        # (0,)
+        # (4, 2, 5, 1, 6, 3, 7)
+        # (7, 4, 8, 2, 5, 9, 1, 3, 6)
+        print(f"Mirror of {name} tree: {tuple(tree.mirror())}")
+        # (0,)
+        # (7, 3, 6, 1, 5, 2, 4)
+        # (6, 3, 1, 9, 5, 2, 8, 4, 7)
+
+
+if __name__ == "__main__":
+    import doctest
+
+    doctest.testmod()
+    main()

--- a/__play4/time_units.rs
+++ b/__play4/time_units.rs
@@ -1,0 +1,162 @@
+//! # Time Unit Conversion
+//!
+//! A unit of time is any particular time interval, used as a standard way of
+//! measuring or expressing duration. The base unit of time in the International
+//! System of Units (SI), and by extension most of the Western world, is the second,
+//! defined as about 9 billion oscillations of the caesium atom.
+//!
+//! More information: <https://en.wikipedia.org/wiki/Unit_of_time>
+
+/// Supported time units for conversion
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum TimeUnit {
+    Seconds,
+    Minutes,
+    Hours,
+    Days,
+    Weeks,
+    Months,
+    Years,
+}
+
+impl TimeUnit {
+    /// Returns the value of the time unit in seconds
+    fn to_seconds(self) -> f64 {
+        match self {
+            TimeUnit::Seconds => 1.0,
+            TimeUnit::Minutes => 60.0,
+            TimeUnit::Hours => 3600.0,
+            TimeUnit::Days => 86400.0,
+            TimeUnit::Weeks => 604800.0,
+            TimeUnit::Months => 2_629_800.0, // Approximate value
+            TimeUnit::Years => 31_557_600.0, // Approximate value
+        }
+    }
+
+    /// Parse a string into a TimeUnit (case-insensitive)
+    fn from_str(s: &str) -> Result<Self, String> {
+        match s.to_lowercase().as_str() {
+            "seconds" => Ok(TimeUnit::Seconds),
+            "minutes" => Ok(TimeUnit::Minutes),
+            "hours" => Ok(TimeUnit::Hours),
+            "days" => Ok(TimeUnit::Days),
+            "weeks" => Ok(TimeUnit::Weeks),
+            "months" => Ok(TimeUnit::Months),
+            "years" => Ok(TimeUnit::Years),
+            _ => Err(format!(
+                "Invalid unit {s} is not in seconds, minutes, hours, days, weeks, months, years."
+            )),
+        }
+    }
+}
+
+/// Convert time from one unit to another
+///
+/// # Arguments
+///
+/// * `time_value` - The time value to convert (must be non-negative)
+/// * `unit_from` - The source unit (case-insensitive)
+/// * `unit_to` - The target unit (case-insensitive)
+///
+/// # Returns
+///
+/// Returns the converted time value rounded to 3 decimal places
+///
+/// # Errors
+///
+/// Returns an error if:
+/// * `time_value` is negative or not a valid number
+/// * `unit_from` or `unit_to` is not a valid time unit
+pub fn convert_time(time_value: f64, unit_from: &str, unit_to: &str) -> Result<f64, String> {
+    // Validate that time_value is non-negative
+    if time_value < 0.0 || time_value.is_nan() || time_value.is_infinite() {
+        return Err("'time_value' must be a non-negative number.".to_string());
+    }
+
+    // Parse units
+    let from_unit = TimeUnit::from_str(unit_from)?;
+    let to_unit = TimeUnit::from_str(unit_to)?;
+
+    // Convert: time_value -> seconds -> target unit
+    let seconds = time_value * from_unit.to_seconds();
+    let result = seconds / to_unit.to_seconds();
+
+    // Round to 3 decimal places
+    Ok((result * 1000.0).round() / 1000.0)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_seconds_to_hours() {
+        assert_eq!(convert_time(3600.0, "seconds", "hours").unwrap(), 1.0);
+    }
+
+    #[test]
+    fn test_case_insensitive() {
+        assert_eq!(convert_time(3500.0, "Seconds", "Hours").unwrap(), 0.972);
+        assert_eq!(convert_time(1.0, "DaYs", "hours").unwrap(), 24.0);
+        assert_eq!(convert_time(120.0, "minutes", "SeCoNdS").unwrap(), 7200.0);
+    }
+
+    #[test]
+    fn test_weeks_to_days() {
+        assert_eq!(convert_time(2.0, "WEEKS", "days").unwrap(), 14.0);
+    }
+
+    #[test]
+    fn test_hours_to_minutes() {
+        assert_eq!(convert_time(0.5, "hours", "MINUTES").unwrap(), 30.0);
+    }
+
+    #[test]
+    fn test_days_to_months() {
+        assert_eq!(convert_time(360.0, "days", "months").unwrap(), 11.828);
+    }
+
+    #[test]
+    fn test_months_to_years() {
+        assert_eq!(convert_time(360.0, "months", "years").unwrap(), 30.0);
+    }
+
+    #[test]
+    fn test_years_to_seconds() {
+        assert_eq!(convert_time(1.0, "years", "seconds").unwrap(), 31_557_600.0);
+    }
+
+    #[test]
+    fn test_negative_value() {
+        let result = convert_time(-3600.0, "seconds", "hours");
+        assert!(result.is_err());
+        assert_eq!(
+            result.unwrap_err(),
+            "'time_value' must be a non-negative number."
+        );
+    }
+
+    #[test]
+    fn test_invalid_from_unit() {
+        let result = convert_time(1.0, "cool", "century");
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("Invalid unit cool"));
+    }
+
+    #[test]
+    fn test_invalid_to_unit() {
+        let result = convert_time(1.0, "seconds", "hot");
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("Invalid unit hot"));
+    }
+
+    #[test]
+    fn test_zero_value() {
+        assert_eq!(convert_time(0.0, "hours", "minutes").unwrap(), 0.0);
+    }
+
+    #[test]
+    fn test_same_unit() {
+        assert_eq!(convert_time(100.0, "seconds", "seconds").unwrap(), 100.0);
+    }
+}


### PR DESCRIPTION
61 Refactored the error messages for missing environmental credentials to provide more granular feedback, such as identifying specifically which API key is missing. This replaces the generic 'Error 1' with actionable instructions for the user. Improved the logger's verbosity during the initial handshake.